### PR TITLE
Remove URLSearchParams from connect method

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -58,11 +58,6 @@ export default class Client {
       });
     }
 
-    const searchParams = new URLSearchParams();
-    searchParams.append("token", session.token_);
-    searchParams.append("lang", this.lang);
-    searchParams.append("format", "json");
-
     const protocol = (this.ssl) ? 'wss' : 'ws';
     const url = `${protocol}://${this.host}:${this.port}/api?format=json&lang=${this.lang}&token=${session.token_}`
 


### PR DESCRIPTION
URLSearchParams doesn't seem to be supported in React Native and it raises "An error occured: %o [ReferenceError: Can't find variable: URLSearchParams]"
This pr removes those lines as the searchParams isn't used while constructing the url anyway.