### PR TITLE
fixed typos in Match interface

### DIFF
--- a/src/socket.ts
+++ b/src/socket.ts
@@ -173,8 +173,8 @@ export interface Match {
   authoritative: boolean;
   label?: string;
   size: number;
-  presences: Match[];
-  self: Match;
+  presences: Presence[];
+  self: Presence;
 }
 
 /** Create a multiplayer match. */


### PR DESCRIPTION
I noticed here that Match interface contains what seems to be invalid field types.

Based on what I see in my console and from naming context, these fields should be of type Presence