### PR TITLE
fixed Client arguments\properties

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -506,9 +506,8 @@ export class Client {
       readonly serverkey = DEFAULT_SERVER_KEY,
       readonly host = DEFAULT_HOST,
       readonly port = DEFAULT_PORT,
-      public useSSL = false,
-      public timeout = DEFAULT_TIMEOUT_MS,
-      public verbose = false) {
+      readonly useSSL = false,
+      readonly timeout = DEFAULT_TIMEOUT_MS) {
     const scheme = (useSSL) ? "https://" : "http://";
     const basePath = `${scheme}${host}:${port}`;
     this.configuration = {


### PR DESCRIPTION
I noticed that there are 3 properties in Client that seem to be confusing for someone who starting with nakama.

Properties\arguments useSSL and timeout can be changed during the life of Client object, but it does not affect any behavior, since only relevant use is inside the constructor.

Obvious fix would be to make useSSL and timeout readonly, since only place where they affect Client's logic is constructor. Also, verbose property don't get used at all.