### PR TITLE
Fix typescript bindings for matchmaking messages.

### DIFF
--- a/dist/socket.d.ts
+++ b/dist/socket.d.ts
@@ -95,8 +95,8 @@ export interface MatchmakerAdd {
         min_count: number;
         max_count: number;
         query: string;
-        string_properties: Map<string, string>;
-        numeric_properties: Map<string, number>;
+        string_properties?: { [key: string]: string };
+        numeric_properties?: { [key: string]: number };
     };
 }
 export interface MatchmakerRemove {
@@ -106,8 +106,8 @@ export interface MatchmakerRemove {
 }
 export interface MatchmakerUser {
     presence: Presence;
-    string_properties: Map<string, string>;
-    numeric_properties: Map<string, number>;
+    string_properties: { [key: string]: string };
+    numeric_properties: { [key: string]: number };
 }
 export interface MatchmakerMatched {
     ticket: string;

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -146,8 +146,8 @@ export interface MatchmakerAdd {
     min_count: number;
     max_count: number;
     query: string;
-    string_properties: Map<string, string>;
-    numeric_properties: Map<string, number>;
+    string_properties?: { [key: string]: string };
+    numeric_properties?: { [key: string]: number };
   };
 }
 
@@ -161,8 +161,8 @@ export interface MatchmakerRemove {
 /** A reference to a user and their matchmaking properties. */
 export interface MatchmakerUser {
   presence: Presence;
-  string_properties: Map<string, string>;
-  numeric_properties: Map<string, number>;
+  string_properties: { [key: string]: string };
+  numeric_properties: { [key: string]: number };
 }
 
 /** Matchmaking result. */


### PR DESCRIPTION
`Map<K, V>` is actually an ES6 type and doesn't correspond to `{ K: V }` at all. This was corrected so that this API can be used easily from within a TypeScript environment.

`string_properties` and `numeric_properties` were also made optional in `matchmaker_add`. I think this is correct as they are left off in an example in the documentation.