### PR TITLE
Accept an array of user presences when sending match data

### DIFF
--- a/packages/nakama-js/dist/nakama-js.cjs.js
+++ b/packages/nakama-js/dist/nakama-js.cjs.js
@@ -1403,8 +1403,6 @@ class DefaultSocket {
       if (this.verbose && window && window.console) {
         console.log("Response: %o", message);
       }
-      console.log("message...");
-      console.log(JSON.stringify(message));
       if (message.cid == void 0) {
         if (message.notifications) {
           message.notifications.notifications.forEach((n) => {
@@ -1529,8 +1527,6 @@ class DefaultSocket {
   }
   send(message) {
     const untypedMessage = message;
-    console.log("untyped message is...");
-    console.log(JSON.stringify(message));
     return new Promise((resolve, reject) => {
       if (!this.adapter.isConnected) {
         reject("Socket connection has not been established yet.");

--- a/packages/nakama-js/dist/nakama-js.cjs.js
+++ b/packages/nakama-js/dist/nakama-js.cjs.js
@@ -20,7 +20,7 @@ var __exportStar = (target, module2) => {
   __markAsModule(target);
   if (typeof module2 === "object" || typeof module2 === "function") {
     for (let key in module2)
-      if (__hasOwnProperty.call(module2, key) && !__hasOwnProperty.call(target, key) && key !== "default")
+      if (!__hasOwnProperty.call(target, key) && key !== "default")
         __defineProperty(target, key, {get: () => module2[key], enumerable: true});
   }
   return target;
@@ -1387,12 +1387,12 @@ class DefaultSocket {
     ++this.nextCid;
     return cid;
   }
-  connect(session3, createStatus = false) {
+  connect(session2, createStatus = false) {
     if (this.adapter.isConnected) {
-      return Promise.resolve(session3);
+      return Promise.resolve(session2);
     }
     const scheme = this.useSSL ? "wss://" : "ws://";
-    this.adapter.connect(scheme, this.host, this.port, createStatus, session3.token);
+    this.adapter.connect(scheme, this.host, this.port, createStatus, session2.token);
     this.adapter.onClose = (evt) => {
       this.ondisconnect(evt);
     };
@@ -1403,6 +1403,8 @@ class DefaultSocket {
       if (this.verbose && window && window.console) {
         console.log("Response: %o", message);
       }
+      console.log("message...");
+      console.log(JSON.stringify(message));
       if (message.cid == void 0) {
         if (message.notifications) {
           message.notifications.notifications.forEach((n) => {
@@ -1454,7 +1456,7 @@ class DefaultSocket {
         if (this.verbose && window && window.console) {
           console.log(evt);
         }
-        resolve(session3);
+        resolve(session2);
       };
       this.adapter.onError = (evt) => {
         reject(evt);
@@ -1527,6 +1529,8 @@ class DefaultSocket {
   }
   send(message) {
     const untypedMessage = message;
+    console.log("untyped message is...");
+    console.log(JSON.stringify(message));
     return new Promise((resolve, reject) => {
       if (!this.adapter.isConnected) {
         reject("Socket connection has not been established yet.");
@@ -1636,14 +1640,14 @@ class DefaultSocket {
       return response.rpc;
     });
   }
-  sendMatchState(matchId, opCode, data, presence) {
+  sendMatchState(matchId, opCode, data, presences) {
     return __async(this, [], function* () {
       return this.send({
         match_data_send: {
           match_id: matchId,
           op_code: opCode,
           data,
-          presence
+          presences: presences != null ? presences : []
         }
       });
     });
@@ -1690,14 +1694,14 @@ class Client {
     };
     this.apiClient = NakamaApi(this.configuration);
   }
-  addGroupUsers(session3, groupId, ids) {
-    this.configuration.bearerToken = session3 && session3.token;
+  addGroupUsers(session2, groupId, ids) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.addGroupUsers(groupId, ids).then((response) => {
       return response !== void 0;
     });
   }
-  addFriends(session3, ids, usernames) {
-    this.configuration.bearerToken = session3 && session3.token;
+  addFriends(session2, ids, usernames) {
+    this.configuration.bearerToken = session2 && session2.token;
     const urlPath = "/v2/friend";
     const queryParams = {
       ids,
@@ -2048,14 +2052,14 @@ class Client {
       return Session.restore(apiSession.token || "");
     });
   }
-  banGroupUsers(session3, groupId, ids) {
-    this.configuration.bearerToken = session3 && session3.token;
+  banGroupUsers(session2, groupId, ids) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.banGroupUsers(groupId, ids).then((response) => {
       return response !== void 0;
     });
   }
-  blockFriends(session3, ids, usernames) {
-    this.configuration.bearerToken = session3 && session3.token;
+  blockFriends(session2, ids, usernames) {
+    this.configuration.bearerToken = session2 && session2.token;
     const urlPath = "/v2/friend/block";
     const queryParams = {
       ids,
@@ -2096,8 +2100,8 @@ class Client {
       return Promise.resolve(response != void 0);
     });
   }
-  createGroup(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  createGroup(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.createGroup(request).then((response) => {
       return Promise.resolve({
         avatar_url: response.avatar_url,
@@ -2118,8 +2122,8 @@ class Client {
   createSocket(useSSL = false, verbose = false, adapter = new WebSocketAdapterText()) {
     return new DefaultSocket(this.host, this.port, useSSL, verbose, adapter);
   }
-  deleteFriends(session3, ids, usernames) {
-    this.configuration.bearerToken = session3 && session3.token;
+  deleteFriends(session2, ids, usernames) {
+    this.configuration.bearerToken = session2 && session2.token;
     const urlPath = "/v2/friend";
     const queryParams = {
       ids,
@@ -2160,14 +2164,14 @@ class Client {
       return Promise.resolve(response != void 0);
     });
   }
-  deleteGroup(session3, groupId) {
-    this.configuration.bearerToken = session3 && session3.token;
+  deleteGroup(session2, groupId) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.deleteGroup(groupId).then((response) => {
       return response !== void 0;
     });
   }
-  deleteNotifications(session3, ids) {
-    this.configuration.bearerToken = session3 && session3.token;
+  deleteNotifications(session2, ids) {
+    this.configuration.bearerToken = session2 && session2.token;
     const urlPath = "/v2/notification";
     const queryParams = {
       ids
@@ -2207,30 +2211,30 @@ class Client {
       return Promise.resolve(response != void 0);
     });
   }
-  deleteStorageObjects(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  deleteStorageObjects(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.deleteStorageObjects(request).then((response) => {
       return Promise.resolve(response != void 0);
     });
   }
-  emitEvent(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  emitEvent(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.event(request).then((response) => {
       return Promise.resolve(response != void 0);
     });
   }
-  getAccount(session3) {
-    this.configuration.bearerToken = session3 && session3.token;
+  getAccount(session2) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.getAccount();
   }
-  importFacebookFriends(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  importFacebookFriends(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.importFacebookFriends(request).then((response) => {
       return response !== void 0;
     });
   }
-  getUsers(session3, ids, usernames, facebookIds) {
-    this.configuration.bearerToken = session3 && session3.token;
+  getUsers(session2, ids, usernames, facebookIds) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.getUsers(ids, usernames, facebookIds).then((response) => {
       var result = {
         users: []
@@ -2261,20 +2265,20 @@ class Client {
       return Promise.resolve(result);
     });
   }
-  joinGroup(session3, groupId) {
-    this.configuration.bearerToken = session3 && session3.token;
+  joinGroup(session2, groupId) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.joinGroup(groupId, {}).then((response) => {
       return response !== void 0;
     });
   }
-  joinTournament(session3, tournamentId) {
-    this.configuration.bearerToken = session3 && session3.token;
+  joinTournament(session2, tournamentId) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.joinTournament(tournamentId, {}).then((response) => {
       return response !== void 0;
     });
   }
-  kickGroupUsers(session3, groupId, ids) {
-    this.configuration.bearerToken = session3 && session3.token;
+  kickGroupUsers(session2, groupId, ids) {
+    this.configuration.bearerToken = session2 && session2.token;
     const urlPath = "/v2/group/" + groupId + "/kick";
     const queryParams = {
       user_ids: ids
@@ -2314,14 +2318,14 @@ class Client {
       return Promise.resolve(response != void 0);
     });
   }
-  leaveGroup(session3, groupId) {
-    this.configuration.bearerToken = session3 && session3.token;
+  leaveGroup(session2, groupId) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.leaveGroup(groupId, {}).then((response) => {
       return response !== void 0;
     });
   }
-  listChannelMessages(session3, channelId, limit, forward, cursor) {
-    this.configuration.bearerToken = session3 && session3.token;
+  listChannelMessages(session2, channelId, limit, forward, cursor) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.listChannelMessages(channelId, limit, forward, cursor).then((response) => {
       var result = {
         messages: [],
@@ -2351,8 +2355,8 @@ class Client {
       return Promise.resolve(result);
     });
   }
-  listGroupUsers(session3, groupId, state, limit, cursor) {
-    this.configuration.bearerToken = session3 && session3.token;
+  listGroupUsers(session2, groupId, state, limit, cursor) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.listGroupUsers(groupId, limit, state, cursor).then((response) => {
       var result = {
         group_users: [],
@@ -2387,8 +2391,8 @@ class Client {
       return Promise.resolve(result);
     });
   }
-  listUserGroups(session3, userId, state, limit, cursor) {
-    this.configuration.bearerToken = session3 && session3.token;
+  listUserGroups(session2, userId, state, limit, cursor) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.listUserGroups(userId, state, limit, cursor).then((response) => {
       var result = {
         user_groups: [],
@@ -2419,8 +2423,8 @@ class Client {
       return Promise.resolve(result);
     });
   }
-  listGroups(session3, name, cursor, limit) {
-    this.configuration.bearerToken = session3 && session3.token;
+  listGroups(session2, name, cursor, limit) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.listGroups(name, cursor, limit).then((response) => {
       var result = {
         groups: []
@@ -2448,56 +2452,56 @@ class Client {
       return Promise.resolve(result);
     });
   }
-  linkCustom(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  linkCustom(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.linkCustom(request).then((response) => {
       return response !== void 0;
     });
   }
-  linkDevice(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  linkDevice(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.linkDevice(request).then((response) => {
       return response !== void 0;
     });
   }
-  linkEmail(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  linkEmail(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.linkEmail(request).then((response) => {
       return response !== void 0;
     });
   }
-  linkFacebook(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  linkFacebook(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.linkFacebook(request).then((response) => {
       return response !== void 0;
     });
   }
-  linkFacebookInstantGame(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  linkFacebookInstantGame(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.linkFacebookInstantGame(request).then((response) => {
       return response !== void 0;
     });
   }
-  linkGoogle(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  linkGoogle(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.linkGoogle(request).then((response) => {
       return response !== void 0;
     });
   }
-  linkGameCenter(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  linkGameCenter(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.linkGameCenter(request).then((response) => {
       return response !== void 0;
     });
   }
-  linkSteam(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  linkSteam(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.linkSteam(request).then((response) => {
       return response !== void 0;
     });
   }
-  listFriends(session3, state, limit, cursor) {
-    this.configuration.bearerToken = session3 && session3.token;
+  listFriends(session2, state, limit, cursor) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.listFriends(limit, state, cursor).then((response) => {
       var result = {
         friends: [],
@@ -2532,8 +2536,8 @@ class Client {
       return Promise.resolve(result);
     });
   }
-  listLeaderboardRecords(session3, leaderboardId, ownerIds, limit, cursor, expiry) {
-    this.configuration.bearerToken = session3 && session3.token;
+  listLeaderboardRecords(session2, leaderboardId, ownerIds, limit, cursor, expiry) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.listLeaderboardRecords(leaderboardId, ownerIds, limit, cursor, expiry).then((response) => {
       var list = {
         next_cursor: response.next_cursor,
@@ -2578,8 +2582,8 @@ class Client {
       return Promise.resolve(list);
     });
   }
-  listLeaderboardRecordsAroundOwner(session3, leaderboardId, ownerId, limit, expiry) {
-    this.configuration.bearerToken = session3 && session3.token;
+  listLeaderboardRecordsAroundOwner(session2, leaderboardId, ownerId, limit, expiry) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.listLeaderboardRecordsAroundOwner(leaderboardId, ownerId, limit, expiry).then((response) => {
       var list = {
         next_cursor: response.next_cursor,
@@ -2624,12 +2628,12 @@ class Client {
       return Promise.resolve(list);
     });
   }
-  listMatches(session3, limit, authoritative, label, minSize, maxSize, query) {
-    this.configuration.bearerToken = session3 && session3.token;
+  listMatches(session2, limit, authoritative, label, minSize, maxSize, query) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.listMatches(limit, authoritative, label, minSize, maxSize, query);
   }
-  listNotifications(session3, limit, cacheableCursor) {
-    this.configuration.bearerToken = session3 && session3.token;
+  listNotifications(session2, limit, cacheableCursor) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.listNotifications(limit, cacheableCursor).then((response) => {
       var result = {
         cacheable_cursor: response.cacheable_cursor,
@@ -2652,8 +2656,8 @@ class Client {
       return Promise.resolve(result);
     });
   }
-  listStorageObjects(session3, collection, userId, limit, cursor) {
-    this.configuration.bearerToken = session3 && session3.token;
+  listStorageObjects(session2, collection, userId, limit, cursor) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.listStorageObjects(collection, userId, limit, cursor).then((response) => {
       var result = {
         objects: [],
@@ -2678,8 +2682,8 @@ class Client {
       return Promise.resolve(result);
     });
   }
-  listTournaments(session3, categoryStart, categoryEnd, startTime, endTime, limit, cursor) {
-    this.configuration.bearerToken = session3 && session3.token;
+  listTournaments(session2, categoryStart, categoryEnd, startTime, endTime, limit, cursor) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.listTournaments(categoryStart, categoryEnd, startTime, endTime, limit, cursor).then((response) => {
       var list = {
         cursor: response.cursor,
@@ -2711,8 +2715,8 @@ class Client {
       return Promise.resolve(list);
     });
   }
-  listTournamentRecords(session3, tournamentId, ownerIds, limit, cursor, expiry) {
-    this.configuration.bearerToken = session3 && session3.token;
+  listTournamentRecords(session2, tournamentId, ownerIds, limit, cursor, expiry) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.listTournamentRecords(tournamentId, ownerIds, limit, cursor, expiry).then((response) => {
       var list = {
         next_cursor: response.next_cursor,
@@ -2757,8 +2761,8 @@ class Client {
       return Promise.resolve(list);
     });
   }
-  listTournamentRecordsAroundOwner(session3, tournamentId, ownerId, limit, expiry) {
-    this.configuration.bearerToken = session3 && session3.token;
+  listTournamentRecordsAroundOwner(session2, tournamentId, ownerId, limit, expiry) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.listTournamentRecordsAroundOwner(tournamentId, ownerId, limit, expiry).then((response) => {
       var list = {
         next_cursor: response.next_cursor,
@@ -2803,8 +2807,8 @@ class Client {
       return Promise.resolve(list);
     });
   }
-  promoteGroupUsers(session3, groupId, ids) {
-    this.configuration.bearerToken = session3 && session3.token;
+  promoteGroupUsers(session2, groupId, ids) {
+    this.configuration.bearerToken = session2 && session2.token;
     const urlPath = "/v2/group/" + groupId + "/promote";
     const queryParams = {
       user_ids: ids
@@ -2844,8 +2848,8 @@ class Client {
       return Promise.resolve(response != void 0);
     });
   }
-  readStorageObjects(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  readStorageObjects(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.readStorageObjects(request).then((response) => {
       var result = {objects: []};
       if (response.objects == null) {
@@ -2867,8 +2871,8 @@ class Client {
       return Promise.resolve(result);
     });
   }
-  rpc(session3, id, input) {
-    this.configuration.bearerToken = session3 && session3.token;
+  rpc(session2, id, input) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.rpcFunc(id, JSON.stringify(input)).then((response) => {
       return Promise.resolve({
         id: response.id,
@@ -2876,9 +2880,9 @@ class Client {
       });
     });
   }
-  rpcGet(id, session3, httpKey, input) {
+  rpcGet(id, session2, httpKey, input) {
     if (!httpKey || httpKey == "") {
-      this.configuration.bearerToken = session3 && session3.token;
+      this.configuration.bearerToken = session2 && session2.token;
     } else {
       this.configuration.username = void 0;
       this.configuration.bearerToken = void 0;
@@ -2894,68 +2898,68 @@ class Client {
       throw err;
     });
   }
-  unlinkCustom(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  unlinkCustom(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.unlinkCustom(request).then((response) => {
       return response !== void 0;
     });
   }
-  unlinkDevice(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  unlinkDevice(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.unlinkDevice(request).then((response) => {
       return response !== void 0;
     });
   }
-  unlinkEmail(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  unlinkEmail(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.unlinkEmail(request).then((response) => {
       return response !== void 0;
     });
   }
-  unlinkFacebook(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  unlinkFacebook(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.unlinkFacebook(request).then((response) => {
       return response !== void 0;
     });
   }
-  unlinkFacebookInstantGame(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  unlinkFacebookInstantGame(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.unlinkFacebookInstantGame(request).then((response) => {
       return response !== void 0;
     });
   }
-  unlinkGoogle(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  unlinkGoogle(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.unlinkGoogle(request).then((response) => {
       return response !== void 0;
     });
   }
-  unlinkGameCenter(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  unlinkGameCenter(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.unlinkGameCenter(request).then((response) => {
       return response !== void 0;
     });
   }
-  unlinkSteam(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  unlinkSteam(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.unlinkSteam(request).then((response) => {
       return response !== void 0;
     });
   }
-  updateAccount(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  updateAccount(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.updateAccount(request).then((response) => {
       return response !== void 0;
     });
   }
-  updateGroup(session3, groupId, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  updateGroup(session2, groupId, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.updateGroup(groupId, request).then((response) => {
       return response !== void 0;
     });
   }
-  writeLeaderboardRecord(session3, leaderboardId, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  writeLeaderboardRecord(session2, leaderboardId, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.writeLeaderboardRecord(leaderboardId, {
       metadata: request.metadata ? JSON.stringify(request.metadata) : void 0,
       score: request.score,
@@ -2976,8 +2980,8 @@ class Client {
       });
     });
   }
-  writeStorageObjects(session3, objects) {
-    this.configuration.bearerToken = session3 && session3.token;
+  writeStorageObjects(session2, objects) {
+    this.configuration.bearerToken = session2 && session2.token;
     var request = {objects: []};
     objects.forEach((o) => {
       request.objects.push({
@@ -2991,8 +2995,8 @@ class Client {
     });
     return this.apiClient.writeStorageObjects(request);
   }
-  writeTournamentRecord(session3, tournamentId, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  writeTournamentRecord(session2, tournamentId, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.writeTournamentRecord(tournamentId, {
       metadata: request.metadata ? JSON.stringify(request.metadata) : void 0,
       score: request.score,

--- a/packages/nakama-js/dist/nakama-js.esm.js
+++ b/packages/nakama-js/dist/nakama-js.esm.js
@@ -1398,8 +1398,6 @@ class DefaultSocket {
       if (this.verbose && window && window.console) {
         console.log("Response: %o", message);
       }
-      console.log("message...");
-      console.log(JSON.stringify(message));
       if (message.cid == void 0) {
         if (message.notifications) {
           message.notifications.notifications.forEach((n) => {
@@ -1524,8 +1522,6 @@ class DefaultSocket {
   }
   send(message) {
     const untypedMessage = message;
-    console.log("untyped message is...");
-    console.log(JSON.stringify(message));
     return new Promise((resolve, reject) => {
       if (!this.adapter.isConnected) {
         reject("Socket connection has not been established yet.");

--- a/packages/nakama-js/dist/nakama-js.esm.js
+++ b/packages/nakama-js/dist/nakama-js.esm.js
@@ -15,7 +15,7 @@ var __exportStar = (target, module) => {
   __markAsModule(target);
   if (typeof module === "object" || typeof module === "function") {
     for (let key in module)
-      if (__hasOwnProperty.call(module, key) && !__hasOwnProperty.call(target, key) && key !== "default")
+      if (!__hasOwnProperty.call(target, key) && key !== "default")
         __defineProperty(target, key, {get: () => module[key], enumerable: true});
   }
   return target;
@@ -1382,12 +1382,12 @@ class DefaultSocket {
     ++this.nextCid;
     return cid;
   }
-  connect(session3, createStatus = false) {
+  connect(session2, createStatus = false) {
     if (this.adapter.isConnected) {
-      return Promise.resolve(session3);
+      return Promise.resolve(session2);
     }
     const scheme = this.useSSL ? "wss://" : "ws://";
-    this.adapter.connect(scheme, this.host, this.port, createStatus, session3.token);
+    this.adapter.connect(scheme, this.host, this.port, createStatus, session2.token);
     this.adapter.onClose = (evt) => {
       this.ondisconnect(evt);
     };
@@ -1398,6 +1398,8 @@ class DefaultSocket {
       if (this.verbose && window && window.console) {
         console.log("Response: %o", message);
       }
+      console.log("message...");
+      console.log(JSON.stringify(message));
       if (message.cid == void 0) {
         if (message.notifications) {
           message.notifications.notifications.forEach((n) => {
@@ -1449,7 +1451,7 @@ class DefaultSocket {
         if (this.verbose && window && window.console) {
           console.log(evt);
         }
-        resolve(session3);
+        resolve(session2);
       };
       this.adapter.onError = (evt) => {
         reject(evt);
@@ -1522,6 +1524,8 @@ class DefaultSocket {
   }
   send(message) {
     const untypedMessage = message;
+    console.log("untyped message is...");
+    console.log(JSON.stringify(message));
     return new Promise((resolve, reject) => {
       if (!this.adapter.isConnected) {
         reject("Socket connection has not been established yet.");
@@ -1631,14 +1635,14 @@ class DefaultSocket {
       return response.rpc;
     });
   }
-  sendMatchState(matchId, opCode, data, presence) {
+  sendMatchState(matchId, opCode, data, presences) {
     return __async(this, [], function* () {
       return this.send({
         match_data_send: {
           match_id: matchId,
           op_code: opCode,
           data,
-          presence
+          presences: presences != null ? presences : []
         }
       });
     });
@@ -1685,14 +1689,14 @@ class Client {
     };
     this.apiClient = NakamaApi(this.configuration);
   }
-  addGroupUsers(session3, groupId, ids) {
-    this.configuration.bearerToken = session3 && session3.token;
+  addGroupUsers(session2, groupId, ids) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.addGroupUsers(groupId, ids).then((response) => {
       return response !== void 0;
     });
   }
-  addFriends(session3, ids, usernames) {
-    this.configuration.bearerToken = session3 && session3.token;
+  addFriends(session2, ids, usernames) {
+    this.configuration.bearerToken = session2 && session2.token;
     const urlPath = "/v2/friend";
     const queryParams = {
       ids,
@@ -2043,14 +2047,14 @@ class Client {
       return Session.restore(apiSession.token || "");
     });
   }
-  banGroupUsers(session3, groupId, ids) {
-    this.configuration.bearerToken = session3 && session3.token;
+  banGroupUsers(session2, groupId, ids) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.banGroupUsers(groupId, ids).then((response) => {
       return response !== void 0;
     });
   }
-  blockFriends(session3, ids, usernames) {
-    this.configuration.bearerToken = session3 && session3.token;
+  blockFriends(session2, ids, usernames) {
+    this.configuration.bearerToken = session2 && session2.token;
     const urlPath = "/v2/friend/block";
     const queryParams = {
       ids,
@@ -2091,8 +2095,8 @@ class Client {
       return Promise.resolve(response != void 0);
     });
   }
-  createGroup(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  createGroup(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.createGroup(request).then((response) => {
       return Promise.resolve({
         avatar_url: response.avatar_url,
@@ -2113,8 +2117,8 @@ class Client {
   createSocket(useSSL = false, verbose = false, adapter = new WebSocketAdapterText()) {
     return new DefaultSocket(this.host, this.port, useSSL, verbose, adapter);
   }
-  deleteFriends(session3, ids, usernames) {
-    this.configuration.bearerToken = session3 && session3.token;
+  deleteFriends(session2, ids, usernames) {
+    this.configuration.bearerToken = session2 && session2.token;
     const urlPath = "/v2/friend";
     const queryParams = {
       ids,
@@ -2155,14 +2159,14 @@ class Client {
       return Promise.resolve(response != void 0);
     });
   }
-  deleteGroup(session3, groupId) {
-    this.configuration.bearerToken = session3 && session3.token;
+  deleteGroup(session2, groupId) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.deleteGroup(groupId).then((response) => {
       return response !== void 0;
     });
   }
-  deleteNotifications(session3, ids) {
-    this.configuration.bearerToken = session3 && session3.token;
+  deleteNotifications(session2, ids) {
+    this.configuration.bearerToken = session2 && session2.token;
     const urlPath = "/v2/notification";
     const queryParams = {
       ids
@@ -2202,30 +2206,30 @@ class Client {
       return Promise.resolve(response != void 0);
     });
   }
-  deleteStorageObjects(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  deleteStorageObjects(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.deleteStorageObjects(request).then((response) => {
       return Promise.resolve(response != void 0);
     });
   }
-  emitEvent(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  emitEvent(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.event(request).then((response) => {
       return Promise.resolve(response != void 0);
     });
   }
-  getAccount(session3) {
-    this.configuration.bearerToken = session3 && session3.token;
+  getAccount(session2) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.getAccount();
   }
-  importFacebookFriends(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  importFacebookFriends(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.importFacebookFriends(request).then((response) => {
       return response !== void 0;
     });
   }
-  getUsers(session3, ids, usernames, facebookIds) {
-    this.configuration.bearerToken = session3 && session3.token;
+  getUsers(session2, ids, usernames, facebookIds) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.getUsers(ids, usernames, facebookIds).then((response) => {
       var result = {
         users: []
@@ -2256,20 +2260,20 @@ class Client {
       return Promise.resolve(result);
     });
   }
-  joinGroup(session3, groupId) {
-    this.configuration.bearerToken = session3 && session3.token;
+  joinGroup(session2, groupId) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.joinGroup(groupId, {}).then((response) => {
       return response !== void 0;
     });
   }
-  joinTournament(session3, tournamentId) {
-    this.configuration.bearerToken = session3 && session3.token;
+  joinTournament(session2, tournamentId) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.joinTournament(tournamentId, {}).then((response) => {
       return response !== void 0;
     });
   }
-  kickGroupUsers(session3, groupId, ids) {
-    this.configuration.bearerToken = session3 && session3.token;
+  kickGroupUsers(session2, groupId, ids) {
+    this.configuration.bearerToken = session2 && session2.token;
     const urlPath = "/v2/group/" + groupId + "/kick";
     const queryParams = {
       user_ids: ids
@@ -2309,14 +2313,14 @@ class Client {
       return Promise.resolve(response != void 0);
     });
   }
-  leaveGroup(session3, groupId) {
-    this.configuration.bearerToken = session3 && session3.token;
+  leaveGroup(session2, groupId) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.leaveGroup(groupId, {}).then((response) => {
       return response !== void 0;
     });
   }
-  listChannelMessages(session3, channelId, limit, forward, cursor) {
-    this.configuration.bearerToken = session3 && session3.token;
+  listChannelMessages(session2, channelId, limit, forward, cursor) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.listChannelMessages(channelId, limit, forward, cursor).then((response) => {
       var result = {
         messages: [],
@@ -2346,8 +2350,8 @@ class Client {
       return Promise.resolve(result);
     });
   }
-  listGroupUsers(session3, groupId, state, limit, cursor) {
-    this.configuration.bearerToken = session3 && session3.token;
+  listGroupUsers(session2, groupId, state, limit, cursor) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.listGroupUsers(groupId, limit, state, cursor).then((response) => {
       var result = {
         group_users: [],
@@ -2382,8 +2386,8 @@ class Client {
       return Promise.resolve(result);
     });
   }
-  listUserGroups(session3, userId, state, limit, cursor) {
-    this.configuration.bearerToken = session3 && session3.token;
+  listUserGroups(session2, userId, state, limit, cursor) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.listUserGroups(userId, state, limit, cursor).then((response) => {
       var result = {
         user_groups: [],
@@ -2414,8 +2418,8 @@ class Client {
       return Promise.resolve(result);
     });
   }
-  listGroups(session3, name, cursor, limit) {
-    this.configuration.bearerToken = session3 && session3.token;
+  listGroups(session2, name, cursor, limit) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.listGroups(name, cursor, limit).then((response) => {
       var result = {
         groups: []
@@ -2443,56 +2447,56 @@ class Client {
       return Promise.resolve(result);
     });
   }
-  linkCustom(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  linkCustom(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.linkCustom(request).then((response) => {
       return response !== void 0;
     });
   }
-  linkDevice(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  linkDevice(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.linkDevice(request).then((response) => {
       return response !== void 0;
     });
   }
-  linkEmail(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  linkEmail(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.linkEmail(request).then((response) => {
       return response !== void 0;
     });
   }
-  linkFacebook(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  linkFacebook(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.linkFacebook(request).then((response) => {
       return response !== void 0;
     });
   }
-  linkFacebookInstantGame(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  linkFacebookInstantGame(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.linkFacebookInstantGame(request).then((response) => {
       return response !== void 0;
     });
   }
-  linkGoogle(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  linkGoogle(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.linkGoogle(request).then((response) => {
       return response !== void 0;
     });
   }
-  linkGameCenter(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  linkGameCenter(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.linkGameCenter(request).then((response) => {
       return response !== void 0;
     });
   }
-  linkSteam(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  linkSteam(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.linkSteam(request).then((response) => {
       return response !== void 0;
     });
   }
-  listFriends(session3, state, limit, cursor) {
-    this.configuration.bearerToken = session3 && session3.token;
+  listFriends(session2, state, limit, cursor) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.listFriends(limit, state, cursor).then((response) => {
       var result = {
         friends: [],
@@ -2527,8 +2531,8 @@ class Client {
       return Promise.resolve(result);
     });
   }
-  listLeaderboardRecords(session3, leaderboardId, ownerIds, limit, cursor, expiry) {
-    this.configuration.bearerToken = session3 && session3.token;
+  listLeaderboardRecords(session2, leaderboardId, ownerIds, limit, cursor, expiry) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.listLeaderboardRecords(leaderboardId, ownerIds, limit, cursor, expiry).then((response) => {
       var list = {
         next_cursor: response.next_cursor,
@@ -2573,8 +2577,8 @@ class Client {
       return Promise.resolve(list);
     });
   }
-  listLeaderboardRecordsAroundOwner(session3, leaderboardId, ownerId, limit, expiry) {
-    this.configuration.bearerToken = session3 && session3.token;
+  listLeaderboardRecordsAroundOwner(session2, leaderboardId, ownerId, limit, expiry) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.listLeaderboardRecordsAroundOwner(leaderboardId, ownerId, limit, expiry).then((response) => {
       var list = {
         next_cursor: response.next_cursor,
@@ -2619,12 +2623,12 @@ class Client {
       return Promise.resolve(list);
     });
   }
-  listMatches(session3, limit, authoritative, label, minSize, maxSize, query) {
-    this.configuration.bearerToken = session3 && session3.token;
+  listMatches(session2, limit, authoritative, label, minSize, maxSize, query) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.listMatches(limit, authoritative, label, minSize, maxSize, query);
   }
-  listNotifications(session3, limit, cacheableCursor) {
-    this.configuration.bearerToken = session3 && session3.token;
+  listNotifications(session2, limit, cacheableCursor) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.listNotifications(limit, cacheableCursor).then((response) => {
       var result = {
         cacheable_cursor: response.cacheable_cursor,
@@ -2647,8 +2651,8 @@ class Client {
       return Promise.resolve(result);
     });
   }
-  listStorageObjects(session3, collection, userId, limit, cursor) {
-    this.configuration.bearerToken = session3 && session3.token;
+  listStorageObjects(session2, collection, userId, limit, cursor) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.listStorageObjects(collection, userId, limit, cursor).then((response) => {
       var result = {
         objects: [],
@@ -2673,8 +2677,8 @@ class Client {
       return Promise.resolve(result);
     });
   }
-  listTournaments(session3, categoryStart, categoryEnd, startTime, endTime, limit, cursor) {
-    this.configuration.bearerToken = session3 && session3.token;
+  listTournaments(session2, categoryStart, categoryEnd, startTime, endTime, limit, cursor) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.listTournaments(categoryStart, categoryEnd, startTime, endTime, limit, cursor).then((response) => {
       var list = {
         cursor: response.cursor,
@@ -2706,8 +2710,8 @@ class Client {
       return Promise.resolve(list);
     });
   }
-  listTournamentRecords(session3, tournamentId, ownerIds, limit, cursor, expiry) {
-    this.configuration.bearerToken = session3 && session3.token;
+  listTournamentRecords(session2, tournamentId, ownerIds, limit, cursor, expiry) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.listTournamentRecords(tournamentId, ownerIds, limit, cursor, expiry).then((response) => {
       var list = {
         next_cursor: response.next_cursor,
@@ -2752,8 +2756,8 @@ class Client {
       return Promise.resolve(list);
     });
   }
-  listTournamentRecordsAroundOwner(session3, tournamentId, ownerId, limit, expiry) {
-    this.configuration.bearerToken = session3 && session3.token;
+  listTournamentRecordsAroundOwner(session2, tournamentId, ownerId, limit, expiry) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.listTournamentRecordsAroundOwner(tournamentId, ownerId, limit, expiry).then((response) => {
       var list = {
         next_cursor: response.next_cursor,
@@ -2798,8 +2802,8 @@ class Client {
       return Promise.resolve(list);
     });
   }
-  promoteGroupUsers(session3, groupId, ids) {
-    this.configuration.bearerToken = session3 && session3.token;
+  promoteGroupUsers(session2, groupId, ids) {
+    this.configuration.bearerToken = session2 && session2.token;
     const urlPath = "/v2/group/" + groupId + "/promote";
     const queryParams = {
       user_ids: ids
@@ -2839,8 +2843,8 @@ class Client {
       return Promise.resolve(response != void 0);
     });
   }
-  readStorageObjects(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  readStorageObjects(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.readStorageObjects(request).then((response) => {
       var result = {objects: []};
       if (response.objects == null) {
@@ -2862,8 +2866,8 @@ class Client {
       return Promise.resolve(result);
     });
   }
-  rpc(session3, id, input) {
-    this.configuration.bearerToken = session3 && session3.token;
+  rpc(session2, id, input) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.rpcFunc(id, JSON.stringify(input)).then((response) => {
       return Promise.resolve({
         id: response.id,
@@ -2871,9 +2875,9 @@ class Client {
       });
     });
   }
-  rpcGet(id, session3, httpKey, input) {
+  rpcGet(id, session2, httpKey, input) {
     if (!httpKey || httpKey == "") {
-      this.configuration.bearerToken = session3 && session3.token;
+      this.configuration.bearerToken = session2 && session2.token;
     } else {
       this.configuration.username = void 0;
       this.configuration.bearerToken = void 0;
@@ -2889,68 +2893,68 @@ class Client {
       throw err;
     });
   }
-  unlinkCustom(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  unlinkCustom(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.unlinkCustom(request).then((response) => {
       return response !== void 0;
     });
   }
-  unlinkDevice(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  unlinkDevice(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.unlinkDevice(request).then((response) => {
       return response !== void 0;
     });
   }
-  unlinkEmail(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  unlinkEmail(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.unlinkEmail(request).then((response) => {
       return response !== void 0;
     });
   }
-  unlinkFacebook(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  unlinkFacebook(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.unlinkFacebook(request).then((response) => {
       return response !== void 0;
     });
   }
-  unlinkFacebookInstantGame(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  unlinkFacebookInstantGame(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.unlinkFacebookInstantGame(request).then((response) => {
       return response !== void 0;
     });
   }
-  unlinkGoogle(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  unlinkGoogle(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.unlinkGoogle(request).then((response) => {
       return response !== void 0;
     });
   }
-  unlinkGameCenter(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  unlinkGameCenter(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.unlinkGameCenter(request).then((response) => {
       return response !== void 0;
     });
   }
-  unlinkSteam(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  unlinkSteam(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.unlinkSteam(request).then((response) => {
       return response !== void 0;
     });
   }
-  updateAccount(session3, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  updateAccount(session2, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.updateAccount(request).then((response) => {
       return response !== void 0;
     });
   }
-  updateGroup(session3, groupId, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  updateGroup(session2, groupId, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.updateGroup(groupId, request).then((response) => {
       return response !== void 0;
     });
   }
-  writeLeaderboardRecord(session3, leaderboardId, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  writeLeaderboardRecord(session2, leaderboardId, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.writeLeaderboardRecord(leaderboardId, {
       metadata: request.metadata ? JSON.stringify(request.metadata) : void 0,
       score: request.score,
@@ -2971,8 +2975,8 @@ class Client {
       });
     });
   }
-  writeStorageObjects(session3, objects) {
-    this.configuration.bearerToken = session3 && session3.token;
+  writeStorageObjects(session2, objects) {
+    this.configuration.bearerToken = session2 && session2.token;
     var request = {objects: []};
     objects.forEach((o) => {
       request.objects.push({
@@ -2986,8 +2990,8 @@ class Client {
     });
     return this.apiClient.writeStorageObjects(request);
   }
-  writeTournamentRecord(session3, tournamentId, request) {
-    this.configuration.bearerToken = session3 && session3.token;
+  writeTournamentRecord(session2, tournamentId, request) {
+    this.configuration.bearerToken = session2 && session2.token;
     return this.apiClient.writeTournamentRecord(tournamentId, {
       metadata: request.metadata ? JSON.stringify(request.metadata) : void 0,
       score: request.score,

--- a/packages/nakama-js/dist/nakama-js.iife.js
+++ b/packages/nakama-js/dist/nakama-js.iife.js
@@ -21,7 +21,7 @@ var nakamajs = (() => {
     __markAsModule(target);
     if (typeof module === "object" || typeof module === "function") {
       for (let key in module)
-        if (__hasOwnProperty.call(module, key) && !__hasOwnProperty.call(target, key) && key !== "default")
+        if (!__hasOwnProperty.call(target, key) && key !== "default")
           __defineProperty(target, key, {get: () => module[key], enumerable: true});
     }
     return target;
@@ -1399,12 +1399,12 @@ var nakamajs = (() => {
       ++this.nextCid;
       return cid;
     }
-    connect(session3, createStatus = false) {
+    connect(session2, createStatus = false) {
       if (this.adapter.isConnected) {
-        return Promise.resolve(session3);
+        return Promise.resolve(session2);
       }
       const scheme = this.useSSL ? "wss://" : "ws://";
-      this.adapter.connect(scheme, this.host, this.port, createStatus, session3.token);
+      this.adapter.connect(scheme, this.host, this.port, createStatus, session2.token);
       this.adapter.onClose = (evt) => {
         this.ondisconnect(evt);
       };
@@ -1415,6 +1415,8 @@ var nakamajs = (() => {
         if (this.verbose && window && window.console) {
           console.log("Response: %o", message);
         }
+        console.log("message...");
+        console.log(JSON.stringify(message));
         if (message.cid == void 0) {
           if (message.notifications) {
             message.notifications.notifications.forEach((n) => {
@@ -1466,7 +1468,7 @@ var nakamajs = (() => {
           if (this.verbose && window && window.console) {
             console.log(evt);
           }
-          resolve(session3);
+          resolve(session2);
         };
         this.adapter.onError = (evt) => {
           reject(evt);
@@ -1539,6 +1541,8 @@ var nakamajs = (() => {
     }
     send(message) {
       const untypedMessage = message;
+      console.log("untyped message is...");
+      console.log(JSON.stringify(message));
       return new Promise((resolve, reject) => {
         if (!this.adapter.isConnected) {
           reject("Socket connection has not been established yet.");
@@ -1648,14 +1652,14 @@ var nakamajs = (() => {
         return response.rpc;
       });
     }
-    sendMatchState(matchId, opCode, data, presence) {
+    sendMatchState(matchId, opCode, data, presences) {
       return __async(this, [], function* () {
         return this.send({
           match_data_send: {
             match_id: matchId,
             op_code: opCode,
             data,
-            presence
+            presences: presences != null ? presences : []
           }
         });
       });
@@ -1702,14 +1706,14 @@ var nakamajs = (() => {
       };
       this.apiClient = NakamaApi(this.configuration);
     }
-    addGroupUsers(session3, groupId, ids) {
-      this.configuration.bearerToken = session3 && session3.token;
+    addGroupUsers(session2, groupId, ids) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.addGroupUsers(groupId, ids).then((response) => {
         return response !== void 0;
       });
     }
-    addFriends(session3, ids, usernames) {
-      this.configuration.bearerToken = session3 && session3.token;
+    addFriends(session2, ids, usernames) {
+      this.configuration.bearerToken = session2 && session2.token;
       const urlPath = "/v2/friend";
       const queryParams = {
         ids,
@@ -2060,14 +2064,14 @@ var nakamajs = (() => {
         return Session.restore(apiSession.token || "");
       });
     }
-    banGroupUsers(session3, groupId, ids) {
-      this.configuration.bearerToken = session3 && session3.token;
+    banGroupUsers(session2, groupId, ids) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.banGroupUsers(groupId, ids).then((response) => {
         return response !== void 0;
       });
     }
-    blockFriends(session3, ids, usernames) {
-      this.configuration.bearerToken = session3 && session3.token;
+    blockFriends(session2, ids, usernames) {
+      this.configuration.bearerToken = session2 && session2.token;
       const urlPath = "/v2/friend/block";
       const queryParams = {
         ids,
@@ -2108,8 +2112,8 @@ var nakamajs = (() => {
         return Promise.resolve(response != void 0);
       });
     }
-    createGroup(session3, request) {
-      this.configuration.bearerToken = session3 && session3.token;
+    createGroup(session2, request) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.createGroup(request).then((response) => {
         return Promise.resolve({
           avatar_url: response.avatar_url,
@@ -2130,8 +2134,8 @@ var nakamajs = (() => {
     createSocket(useSSL = false, verbose = false, adapter = new WebSocketAdapterText()) {
       return new DefaultSocket(this.host, this.port, useSSL, verbose, adapter);
     }
-    deleteFriends(session3, ids, usernames) {
-      this.configuration.bearerToken = session3 && session3.token;
+    deleteFriends(session2, ids, usernames) {
+      this.configuration.bearerToken = session2 && session2.token;
       const urlPath = "/v2/friend";
       const queryParams = {
         ids,
@@ -2172,14 +2176,14 @@ var nakamajs = (() => {
         return Promise.resolve(response != void 0);
       });
     }
-    deleteGroup(session3, groupId) {
-      this.configuration.bearerToken = session3 && session3.token;
+    deleteGroup(session2, groupId) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.deleteGroup(groupId).then((response) => {
         return response !== void 0;
       });
     }
-    deleteNotifications(session3, ids) {
-      this.configuration.bearerToken = session3 && session3.token;
+    deleteNotifications(session2, ids) {
+      this.configuration.bearerToken = session2 && session2.token;
       const urlPath = "/v2/notification";
       const queryParams = {
         ids
@@ -2219,30 +2223,30 @@ var nakamajs = (() => {
         return Promise.resolve(response != void 0);
       });
     }
-    deleteStorageObjects(session3, request) {
-      this.configuration.bearerToken = session3 && session3.token;
+    deleteStorageObjects(session2, request) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.deleteStorageObjects(request).then((response) => {
         return Promise.resolve(response != void 0);
       });
     }
-    emitEvent(session3, request) {
-      this.configuration.bearerToken = session3 && session3.token;
+    emitEvent(session2, request) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.event(request).then((response) => {
         return Promise.resolve(response != void 0);
       });
     }
-    getAccount(session3) {
-      this.configuration.bearerToken = session3 && session3.token;
+    getAccount(session2) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.getAccount();
     }
-    importFacebookFriends(session3, request) {
-      this.configuration.bearerToken = session3 && session3.token;
+    importFacebookFriends(session2, request) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.importFacebookFriends(request).then((response) => {
         return response !== void 0;
       });
     }
-    getUsers(session3, ids, usernames, facebookIds) {
-      this.configuration.bearerToken = session3 && session3.token;
+    getUsers(session2, ids, usernames, facebookIds) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.getUsers(ids, usernames, facebookIds).then((response) => {
         var result = {
           users: []
@@ -2273,20 +2277,20 @@ var nakamajs = (() => {
         return Promise.resolve(result);
       });
     }
-    joinGroup(session3, groupId) {
-      this.configuration.bearerToken = session3 && session3.token;
+    joinGroup(session2, groupId) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.joinGroup(groupId, {}).then((response) => {
         return response !== void 0;
       });
     }
-    joinTournament(session3, tournamentId) {
-      this.configuration.bearerToken = session3 && session3.token;
+    joinTournament(session2, tournamentId) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.joinTournament(tournamentId, {}).then((response) => {
         return response !== void 0;
       });
     }
-    kickGroupUsers(session3, groupId, ids) {
-      this.configuration.bearerToken = session3 && session3.token;
+    kickGroupUsers(session2, groupId, ids) {
+      this.configuration.bearerToken = session2 && session2.token;
       const urlPath = "/v2/group/" + groupId + "/kick";
       const queryParams = {
         user_ids: ids
@@ -2326,14 +2330,14 @@ var nakamajs = (() => {
         return Promise.resolve(response != void 0);
       });
     }
-    leaveGroup(session3, groupId) {
-      this.configuration.bearerToken = session3 && session3.token;
+    leaveGroup(session2, groupId) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.leaveGroup(groupId, {}).then((response) => {
         return response !== void 0;
       });
     }
-    listChannelMessages(session3, channelId, limit, forward, cursor) {
-      this.configuration.bearerToken = session3 && session3.token;
+    listChannelMessages(session2, channelId, limit, forward, cursor) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.listChannelMessages(channelId, limit, forward, cursor).then((response) => {
         var result = {
           messages: [],
@@ -2363,8 +2367,8 @@ var nakamajs = (() => {
         return Promise.resolve(result);
       });
     }
-    listGroupUsers(session3, groupId, state, limit, cursor) {
-      this.configuration.bearerToken = session3 && session3.token;
+    listGroupUsers(session2, groupId, state, limit, cursor) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.listGroupUsers(groupId, limit, state, cursor).then((response) => {
         var result = {
           group_users: [],
@@ -2399,8 +2403,8 @@ var nakamajs = (() => {
         return Promise.resolve(result);
       });
     }
-    listUserGroups(session3, userId, state, limit, cursor) {
-      this.configuration.bearerToken = session3 && session3.token;
+    listUserGroups(session2, userId, state, limit, cursor) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.listUserGroups(userId, state, limit, cursor).then((response) => {
         var result = {
           user_groups: [],
@@ -2431,8 +2435,8 @@ var nakamajs = (() => {
         return Promise.resolve(result);
       });
     }
-    listGroups(session3, name, cursor, limit) {
-      this.configuration.bearerToken = session3 && session3.token;
+    listGroups(session2, name, cursor, limit) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.listGroups(name, cursor, limit).then((response) => {
         var result = {
           groups: []
@@ -2460,56 +2464,56 @@ var nakamajs = (() => {
         return Promise.resolve(result);
       });
     }
-    linkCustom(session3, request) {
-      this.configuration.bearerToken = session3 && session3.token;
+    linkCustom(session2, request) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.linkCustom(request).then((response) => {
         return response !== void 0;
       });
     }
-    linkDevice(session3, request) {
-      this.configuration.bearerToken = session3 && session3.token;
+    linkDevice(session2, request) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.linkDevice(request).then((response) => {
         return response !== void 0;
       });
     }
-    linkEmail(session3, request) {
-      this.configuration.bearerToken = session3 && session3.token;
+    linkEmail(session2, request) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.linkEmail(request).then((response) => {
         return response !== void 0;
       });
     }
-    linkFacebook(session3, request) {
-      this.configuration.bearerToken = session3 && session3.token;
+    linkFacebook(session2, request) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.linkFacebook(request).then((response) => {
         return response !== void 0;
       });
     }
-    linkFacebookInstantGame(session3, request) {
-      this.configuration.bearerToken = session3 && session3.token;
+    linkFacebookInstantGame(session2, request) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.linkFacebookInstantGame(request).then((response) => {
         return response !== void 0;
       });
     }
-    linkGoogle(session3, request) {
-      this.configuration.bearerToken = session3 && session3.token;
+    linkGoogle(session2, request) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.linkGoogle(request).then((response) => {
         return response !== void 0;
       });
     }
-    linkGameCenter(session3, request) {
-      this.configuration.bearerToken = session3 && session3.token;
+    linkGameCenter(session2, request) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.linkGameCenter(request).then((response) => {
         return response !== void 0;
       });
     }
-    linkSteam(session3, request) {
-      this.configuration.bearerToken = session3 && session3.token;
+    linkSteam(session2, request) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.linkSteam(request).then((response) => {
         return response !== void 0;
       });
     }
-    listFriends(session3, state, limit, cursor) {
-      this.configuration.bearerToken = session3 && session3.token;
+    listFriends(session2, state, limit, cursor) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.listFriends(limit, state, cursor).then((response) => {
         var result = {
           friends: [],
@@ -2544,8 +2548,8 @@ var nakamajs = (() => {
         return Promise.resolve(result);
       });
     }
-    listLeaderboardRecords(session3, leaderboardId, ownerIds, limit, cursor, expiry) {
-      this.configuration.bearerToken = session3 && session3.token;
+    listLeaderboardRecords(session2, leaderboardId, ownerIds, limit, cursor, expiry) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.listLeaderboardRecords(leaderboardId, ownerIds, limit, cursor, expiry).then((response) => {
         var list = {
           next_cursor: response.next_cursor,
@@ -2590,8 +2594,8 @@ var nakamajs = (() => {
         return Promise.resolve(list);
       });
     }
-    listLeaderboardRecordsAroundOwner(session3, leaderboardId, ownerId, limit, expiry) {
-      this.configuration.bearerToken = session3 && session3.token;
+    listLeaderboardRecordsAroundOwner(session2, leaderboardId, ownerId, limit, expiry) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.listLeaderboardRecordsAroundOwner(leaderboardId, ownerId, limit, expiry).then((response) => {
         var list = {
           next_cursor: response.next_cursor,
@@ -2636,12 +2640,12 @@ var nakamajs = (() => {
         return Promise.resolve(list);
       });
     }
-    listMatches(session3, limit, authoritative, label, minSize, maxSize, query) {
-      this.configuration.bearerToken = session3 && session3.token;
+    listMatches(session2, limit, authoritative, label, minSize, maxSize, query) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.listMatches(limit, authoritative, label, minSize, maxSize, query);
     }
-    listNotifications(session3, limit, cacheableCursor) {
-      this.configuration.bearerToken = session3 && session3.token;
+    listNotifications(session2, limit, cacheableCursor) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.listNotifications(limit, cacheableCursor).then((response) => {
         var result = {
           cacheable_cursor: response.cacheable_cursor,
@@ -2664,8 +2668,8 @@ var nakamajs = (() => {
         return Promise.resolve(result);
       });
     }
-    listStorageObjects(session3, collection, userId, limit, cursor) {
-      this.configuration.bearerToken = session3 && session3.token;
+    listStorageObjects(session2, collection, userId, limit, cursor) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.listStorageObjects(collection, userId, limit, cursor).then((response) => {
         var result = {
           objects: [],
@@ -2690,8 +2694,8 @@ var nakamajs = (() => {
         return Promise.resolve(result);
       });
     }
-    listTournaments(session3, categoryStart, categoryEnd, startTime, endTime, limit, cursor) {
-      this.configuration.bearerToken = session3 && session3.token;
+    listTournaments(session2, categoryStart, categoryEnd, startTime, endTime, limit, cursor) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.listTournaments(categoryStart, categoryEnd, startTime, endTime, limit, cursor).then((response) => {
         var list = {
           cursor: response.cursor,
@@ -2723,8 +2727,8 @@ var nakamajs = (() => {
         return Promise.resolve(list);
       });
     }
-    listTournamentRecords(session3, tournamentId, ownerIds, limit, cursor, expiry) {
-      this.configuration.bearerToken = session3 && session3.token;
+    listTournamentRecords(session2, tournamentId, ownerIds, limit, cursor, expiry) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.listTournamentRecords(tournamentId, ownerIds, limit, cursor, expiry).then((response) => {
         var list = {
           next_cursor: response.next_cursor,
@@ -2769,8 +2773,8 @@ var nakamajs = (() => {
         return Promise.resolve(list);
       });
     }
-    listTournamentRecordsAroundOwner(session3, tournamentId, ownerId, limit, expiry) {
-      this.configuration.bearerToken = session3 && session3.token;
+    listTournamentRecordsAroundOwner(session2, tournamentId, ownerId, limit, expiry) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.listTournamentRecordsAroundOwner(tournamentId, ownerId, limit, expiry).then((response) => {
         var list = {
           next_cursor: response.next_cursor,
@@ -2815,8 +2819,8 @@ var nakamajs = (() => {
         return Promise.resolve(list);
       });
     }
-    promoteGroupUsers(session3, groupId, ids) {
-      this.configuration.bearerToken = session3 && session3.token;
+    promoteGroupUsers(session2, groupId, ids) {
+      this.configuration.bearerToken = session2 && session2.token;
       const urlPath = "/v2/group/" + groupId + "/promote";
       const queryParams = {
         user_ids: ids
@@ -2856,8 +2860,8 @@ var nakamajs = (() => {
         return Promise.resolve(response != void 0);
       });
     }
-    readStorageObjects(session3, request) {
-      this.configuration.bearerToken = session3 && session3.token;
+    readStorageObjects(session2, request) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.readStorageObjects(request).then((response) => {
         var result = {objects: []};
         if (response.objects == null) {
@@ -2879,8 +2883,8 @@ var nakamajs = (() => {
         return Promise.resolve(result);
       });
     }
-    rpc(session3, id, input) {
-      this.configuration.bearerToken = session3 && session3.token;
+    rpc(session2, id, input) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.rpcFunc(id, JSON.stringify(input)).then((response) => {
         return Promise.resolve({
           id: response.id,
@@ -2888,9 +2892,9 @@ var nakamajs = (() => {
         });
       });
     }
-    rpcGet(id, session3, httpKey, input) {
+    rpcGet(id, session2, httpKey, input) {
       if (!httpKey || httpKey == "") {
-        this.configuration.bearerToken = session3 && session3.token;
+        this.configuration.bearerToken = session2 && session2.token;
       } else {
         this.configuration.username = void 0;
         this.configuration.bearerToken = void 0;
@@ -2906,68 +2910,68 @@ var nakamajs = (() => {
         throw err;
       });
     }
-    unlinkCustom(session3, request) {
-      this.configuration.bearerToken = session3 && session3.token;
+    unlinkCustom(session2, request) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.unlinkCustom(request).then((response) => {
         return response !== void 0;
       });
     }
-    unlinkDevice(session3, request) {
-      this.configuration.bearerToken = session3 && session3.token;
+    unlinkDevice(session2, request) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.unlinkDevice(request).then((response) => {
         return response !== void 0;
       });
     }
-    unlinkEmail(session3, request) {
-      this.configuration.bearerToken = session3 && session3.token;
+    unlinkEmail(session2, request) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.unlinkEmail(request).then((response) => {
         return response !== void 0;
       });
     }
-    unlinkFacebook(session3, request) {
-      this.configuration.bearerToken = session3 && session3.token;
+    unlinkFacebook(session2, request) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.unlinkFacebook(request).then((response) => {
         return response !== void 0;
       });
     }
-    unlinkFacebookInstantGame(session3, request) {
-      this.configuration.bearerToken = session3 && session3.token;
+    unlinkFacebookInstantGame(session2, request) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.unlinkFacebookInstantGame(request).then((response) => {
         return response !== void 0;
       });
     }
-    unlinkGoogle(session3, request) {
-      this.configuration.bearerToken = session3 && session3.token;
+    unlinkGoogle(session2, request) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.unlinkGoogle(request).then((response) => {
         return response !== void 0;
       });
     }
-    unlinkGameCenter(session3, request) {
-      this.configuration.bearerToken = session3 && session3.token;
+    unlinkGameCenter(session2, request) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.unlinkGameCenter(request).then((response) => {
         return response !== void 0;
       });
     }
-    unlinkSteam(session3, request) {
-      this.configuration.bearerToken = session3 && session3.token;
+    unlinkSteam(session2, request) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.unlinkSteam(request).then((response) => {
         return response !== void 0;
       });
     }
-    updateAccount(session3, request) {
-      this.configuration.bearerToken = session3 && session3.token;
+    updateAccount(session2, request) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.updateAccount(request).then((response) => {
         return response !== void 0;
       });
     }
-    updateGroup(session3, groupId, request) {
-      this.configuration.bearerToken = session3 && session3.token;
+    updateGroup(session2, groupId, request) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.updateGroup(groupId, request).then((response) => {
         return response !== void 0;
       });
     }
-    writeLeaderboardRecord(session3, leaderboardId, request) {
-      this.configuration.bearerToken = session3 && session3.token;
+    writeLeaderboardRecord(session2, leaderboardId, request) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.writeLeaderboardRecord(leaderboardId, {
         metadata: request.metadata ? JSON.stringify(request.metadata) : void 0,
         score: request.score,
@@ -2988,8 +2992,8 @@ var nakamajs = (() => {
         });
       });
     }
-    writeStorageObjects(session3, objects) {
-      this.configuration.bearerToken = session3 && session3.token;
+    writeStorageObjects(session2, objects) {
+      this.configuration.bearerToken = session2 && session2.token;
       var request = {objects: []};
       objects.forEach((o) => {
         request.objects.push({
@@ -3003,8 +3007,8 @@ var nakamajs = (() => {
       });
       return this.apiClient.writeStorageObjects(request);
     }
-    writeTournamentRecord(session3, tournamentId, request) {
-      this.configuration.bearerToken = session3 && session3.token;
+    writeTournamentRecord(session2, tournamentId, request) {
+      this.configuration.bearerToken = session2 && session2.token;
       return this.apiClient.writeTournamentRecord(tournamentId, {
         metadata: request.metadata ? JSON.stringify(request.metadata) : void 0,
         score: request.score,

--- a/packages/nakama-js/dist/nakama-js.iife.js
+++ b/packages/nakama-js/dist/nakama-js.iife.js
@@ -1415,8 +1415,6 @@ var nakamajs = (() => {
         if (this.verbose && window && window.console) {
           console.log("Response: %o", message);
         }
-        console.log("message...");
-        console.log(JSON.stringify(message));
         if (message.cid == void 0) {
           if (message.notifications) {
             message.notifications.notifications.forEach((n) => {
@@ -1541,8 +1539,6 @@ var nakamajs = (() => {
     }
     send(message) {
       const untypedMessage = message;
-      console.log("untyped message is...");
-      console.log(JSON.stringify(message));
       return new Promise((resolve, reject) => {
         if (!this.adapter.isConnected) {
           reject("Socket connection has not been established yet.");

--- a/packages/nakama-js/socket.ts
+++ b/packages/nakama-js/socket.ts
@@ -220,7 +220,7 @@ export interface MatchData {
   match_id: string;
   op_code: number;
   data: any;
-  presence: Presence;
+  presences: Presence[];
 }
 
 /** Send a message contains match data. */
@@ -307,7 +307,7 @@ export interface Socket {
 
   // Send input to a multiplayer match on the server.
   // When no presences are supplied the new match state will be sent to all presences.
-  sendMatchState(matchId: string, opCode : number, data: any, presence? : Presence) : Promise<void>;
+  sendMatchState(matchId: string, opCode : number, data: any, presence? : Presence[]) : Promise<void>;
 
   // Unfollow one or more users from their status updates.
   unfollowUsers(user_ids : string[]) : Promise<void>;
@@ -676,14 +676,14 @@ export class DefaultSocket implements Socket {
       return response.rpc;
   }
 
-  async sendMatchState(matchId: string, opCode : number, data: any, presence? : Presence): Promise<void> {
+  async sendMatchState(matchId: string, opCode : number, data: any, presences? : Presence[]): Promise<void> {
     return this.send(
       {
         match_data_send: {
           match_id : matchId,
           op_code: opCode,
           data: data,
-          presence: presence
+          presences: presences ?? []
         }
     });
   }

--- a/packages/nakama-js/socket.ts
+++ b/packages/nakama-js/socket.ts
@@ -265,7 +265,7 @@ export interface Socket {
   connect(session: Session, createStatus: boolean): Promise<Session>;
   // Disconnect from the server.
   disconnect(fireDisconnectEvent: boolean): void;
-  // Send message to the server. This method remains in the API for backwards compatibility. 
+  // Send message to the server. This method remains in the API for backwards compatibility.
   // We recommend that you use the other socket-based methods below for improved
   // type checking and code readability.
   send(message: ChannelJoin | ChannelLeave | ChannelMessageSend |
@@ -274,10 +274,10 @@ export interface Socket {
     StatusFollow | StatusUnfollow | StatusUpdate): Promise<any>;
 
   /// Join the matchmaker pool and search for opponents on the server.
-  addMatchmaker(query : string, minCount : number, maxCount : number,  
+  addMatchmaker(query : string, minCount : number, maxCount : number,
     stringProperties? : Record<string, string>, numericProperties? : Record<string, number>)
     : Promise<MatchmakerMatched>;
-  
+
   // Create a multiplayer match on the server.
   createMatch() : Promise<Match>;
 
@@ -288,7 +288,7 @@ export interface Socket {
   joinChat(target: string, type: number, persistence: boolean, hidden: boolean) : Promise<Channel>;
 
   // Join a multiplayer match.
-  joinMatch(match_id?: string, token?: string, metadata?: {}) : Promise<Match>; 
+  joinMatch(match_id?: string, token?: string, metadata?: {}) : Promise<Match>;
 
   // Leave a chat channel on the server.
   leaveChat(channel_id: string) : Promise<void>;
@@ -298,7 +298,7 @@ export interface Socket {
 
   // Remove a chat message from a chat channel on the server.
   removeChatMessage(channel_id: string, message_id: string) : Promise<ChannelMessageAck>;
-  
+
   // Leave the matchmaker pool with the provided ticket.
   removeMatchmaker(ticket : string) : Promise<void>;
 
@@ -367,7 +367,7 @@ export class DefaultSocket implements Socket {
       ) {
     this.cIds = {};
     this.nextCid = 1;
-  }  
+  }
 
   generatecid(): string {
     const cid = this.nextCid.toString();
@@ -395,6 +395,9 @@ export class DefaultSocket implements Socket {
       if (this.verbose && window && window.console) {
         console.log("Response: %o", message);
       }
+
+      console.log("message...")
+      console.log(JSON.stringify(message));
 
       // Inbound message from server.
       if (message.cid == undefined) {
@@ -540,6 +543,8 @@ export class DefaultSocket implements Socket {
     Rpc | StatusFollow | StatusUnfollow | StatusUpdate): Promise<any> {
     const untypedMessage = message as any;
 
+    console.log("untyped message is...");
+    console.log(JSON.stringify(message));
 
     return new Promise((resolve, reject) => {
       if (!this.adapter.isConnected) {
@@ -575,23 +580,23 @@ export class DefaultSocket implements Socket {
   }
 
 
-  async addMatchmaker(query : string, minCount : number, maxCount : number,  
+  async addMatchmaker(query : string, minCount : number, maxCount : number,
     stringProperties? : Record<string, string>, numericProperties? : Record<string, number>)
     : Promise<MatchmakerMatched> {
 
-      const matchMakerAdd : MatchmakerAdd = 
+      const matchMakerAdd : MatchmakerAdd =
       {
         "matchmaker_add": {
-          min_count: minCount, 
-          max_count: maxCount, 
-          query: query, 
-          string_properties: stringProperties, 
+          min_count: minCount,
+          max_count: maxCount,
+          query: query,
+          string_properties: stringProperties,
           numeric_properties: numericProperties
         }
       };
 
       const response = await this.send(matchMakerAdd);
-      
+
       return response.matchmaker_ticket;
     }
 
@@ -599,20 +604,20 @@ export class DefaultSocket implements Socket {
     const response = await this.send({match_create: {}});
     return response.match;
   }
-  
+
   async followUsers(userIds : string[]): Promise<Status> {
     const response = await this.send({status_follow: {user_ids: userIds}});
     return response.status;
   }
-  
+
   async joinChat(target: string, type: number, persistence: boolean, hidden: boolean): Promise<Channel> {
-  
+
     const response = await this.send({
         channel_join: {
             target: target,
             type: type,
             persistence: persistence,
-            hidden: hidden     
+            hidden: hidden
         }
       }
     );
@@ -622,7 +627,7 @@ export class DefaultSocket implements Socket {
 
   async joinMatch(match_id?: string, token?: string, metadata?: {}): Promise<Match> {
 
-    const join : JoinMatch = {match_join: {metadata: metadata}}; 
+    const join : JoinMatch = {match_join: {metadata: metadata}};
 
     if (token)
     {
@@ -640,7 +645,7 @@ export class DefaultSocket implements Socket {
   leaveChat(channel_id: string): Promise<void> {
     return this.send({channel_leave: {channel_id: channel_id}});
   }
-  
+
   leaveMatch(matchId: string): Promise<void> {
     return this.send({match_leave: {match_id: matchId}});
   }
@@ -650,7 +655,7 @@ export class DefaultSocket implements Socket {
     (
       {
         channel_message_remove: {
-          channel_id: channel_id, 
+          channel_id: channel_id,
           message_id: message_id
         }
       }

--- a/packages/nakama-js/socket.ts
+++ b/packages/nakama-js/socket.ts
@@ -396,9 +396,6 @@ export class DefaultSocket implements Socket {
         console.log("Response: %o", message);
       }
 
-      console.log("message...")
-      console.log(JSON.stringify(message));
-
       // Inbound message from server.
       if (message.cid == undefined) {
         if (message.notifications) {
@@ -542,9 +539,6 @@ export class DefaultSocket implements Socket {
     JoinMatch | LeaveMatch | MatchDataSend | MatchmakerAdd | MatchmakerRemove |
     Rpc | StatusFollow | StatusUnfollow | StatusUpdate): Promise<any> {
     const untypedMessage = message as any;
-
-    console.log("untyped message is...");
-    console.log(JSON.stringify(message));
 
     return new Promise((resolve, reject) => {
       if (!this.adapter.isConnected) {

--- a/test/socket-match.test.ts
+++ b/test/socket-match.test.ts
@@ -228,7 +228,6 @@ describe('Match Tests', () => {
           {
             presenceToReceive = socket3Presence;
             resolve();
-
           }
         }
       });

--- a/test/socket-match.test.ts
+++ b/test/socket-match.test.ts
@@ -101,10 +101,12 @@ describe('Match Tests', () => {
     const matchData = await page.evaluate(async (customid1, customid2, payload, adapter) => {
       const client1 = new nakamajs.Client();
       const client2 = new nakamajs.Client();
+
       const socket1 = client1.createSocket(false, false,
         adapter == AdapterType.Protobuf ? new nakamajsprotobuf.WebSocketAdapterPb() : new nakamajs.WebSocketAdapterText());
 
-      const socket2 = client2.createSocket(false, false);
+      const socket2 = client2.createSocket(false, false,
+        adapter == AdapterType.Protobuf ? new nakamajsprotobuf.WebSocketAdapterPb() : new nakamajs.WebSocketAdapterText());
 
       var promise1 = new Promise<MatchData>((resolve, reject) => {
         socket2.onmatchdata = (matchdata) => {

--- a/test/socket-match.test.ts
+++ b/test/socket-match.test.ts
@@ -19,6 +19,7 @@ import * as nakamajs from "../packages/nakama-js";
 import {Match, MatchData} from "../packages/nakama-js/socket"
 import * as nakamajsprotobuf from "../packages/nakama-js-protobuf";
 import {adapters, createPage, generateid, AdapterType} from "./utils"
+import { WebSocketAdapter } from "../packages/nakama-js";
 
 describe('Match Tests', () => {
 
@@ -28,7 +29,7 @@ describe('Match Tests', () => {
     const customid = generateid();
     const match = await page.evaluate(async (customid, adapter) => {
       const client = new nakamajs.Client();
-      const socket = client.createSocket(false, false, 
+      const socket = client.createSocket(false, false,
         adapter == AdapterType.Protobuf ? new nakamajsprotobuf.WebSocketAdapterPb() : new nakamajs.WebSocketAdapterText());
 
       const session = await client.authenticateCustom({ id: customid });
@@ -51,7 +52,7 @@ describe('Match Tests', () => {
 
     const match : Match = await page.evaluate(async (customid, adapter) => {
       const client = new nakamajs.Client();
-      const socket = client.createSocket(false, false, 
+      const socket = client.createSocket(false, false,
         adapter == AdapterType.Protobuf ? new nakamajsprotobuf.WebSocketAdapterPb() : new nakamajs.WebSocketAdapterText());
 
       const session = await client.authenticateCustom({ id: customid });
@@ -98,11 +99,11 @@ describe('Match Tests', () => {
     const PAYLOAD = { "hello": "world" };
 
     const matchData = await page.evaluate(async (customid1, customid2, payload, adapter) => {
-      const client1 = new nakamajs.Client();      
+      const client1 = new nakamajs.Client();
       const client2 = new nakamajs.Client();
-      const socket1 = client1.createSocket(false, false, 
+      const socket1 = client1.createSocket(false, false,
         adapter == AdapterType.Protobuf ? new nakamajsprotobuf.WebSocketAdapterPb() : new nakamajs.WebSocketAdapterText());
-      
+
       const socket2 = client2.createSocket(false, false);
 
       var promise1 = new Promise<MatchData>((resolve, reject) => {
@@ -124,6 +125,59 @@ describe('Match Tests', () => {
 
       return Promise.race([promise1, promise2]);
     }, customid1, customid2, PAYLOAD, adapter);
+
+    expect(matchData).not.toBeNull();
+    expect(matchData.data).toEqual(PAYLOAD);
+  });
+
+  it.each(adapters)('should join a match, then send data to certain presences', async (adapter) => {
+    const page = await createPage();
+
+    const customid1 = generateid();
+    const customid2 = generateid();
+    const customid3 = generateid();
+
+    const PAYLOAD = { "hello": "world" };
+
+    const matchData = await page.evaluate(async (customid1, customid2, customid3, payload, adapterType) => {
+      const client1 = new nakamajs.Client();
+      const client2 = new nakamajs.Client();
+      const client3 = new nakamajs.Client();
+
+      const socket1 = client1.createSocket(false, false, adapterType == AdapterType.Protobuf ? new nakamajsprotobuf.WebSocketAdapterPb() : new nakamajs.WebSocketAdapterText());
+      const socket2 = client2.createSocket(false, false, adapterType == AdapterType.Protobuf ? new nakamajsprotobuf.WebSocketAdapterPb() : new nakamajs.WebSocketAdapterText());
+      const socket3 = client3.createSocket(false, false, adapterType == AdapterType.Protobuf ? new nakamajsprotobuf.WebSocketAdapterPb() : new nakamajs.WebSocketAdapterText());
+
+      const session1 = await client1.authenticateCustom({ id: customid1 });
+      await socket1.connect(session1, false);
+
+      const session2 = await client2.authenticateCustom({ id: customid2 });
+      await socket2.connect(session2, false);
+
+      const session3 = await client3.authenticateCustom({ id: customid3 });
+      await socket3.connect(session3, false);
+
+      const initialMatch = await socket1.createMatch();
+
+      await socket2.joinMatch(initialMatch.match_id);
+
+      const fullMatch = await socket3.joinMatch(initialMatch.match_id);
+
+      const sentToSocket2Promise = new Promise<MatchData>((resolve, reject) => {
+        socket2.onmatchdata = (matchdata) => {
+          resolve(matchdata);
+        }
+      });
+
+      const timeout = new Promise<null>((resolve, reject) => {
+        setTimeout(reject, 5000, "did not receive match data - timed out.")
+      });
+
+      const socket2Presence = fullMatch.presences.find(presence => presence.user_id = customid2);
+      await socket1.sendMatchState(fullMatch.match_id, 20, payload);
+
+      return Promise.race([sentToSocket2Promise, timeout]);
+    }, customid1, customid2, customid3, PAYLOAD, adapter);
 
     expect(matchData).not.toBeNull();
     expect(matchData.data).toEqual(PAYLOAD);


### PR DESCRIPTION
The previous implementation only accepted a single presence to specify match data towards. This PR allows you to send match data to multiple presences while excluding others, which brings it in line with the dotnet sdk.

I also added tests.

I built this off the #66 branch because it makes changes to test code.

