### PR TITLE
Reexport socket for complete d.ts typings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,3 +19,9 @@ import "whatwg-fetch";
 
 export * from "./client";
 export * from "./session";
+export * from "./socket";
+
+/**
+ * Reexported due to duplicate definition of ChannelMessage in [Client]{@link ./client.ts} and [Session]{@link ./session.ts}
+ */
+export { ChannelMessage } from "./client";


### PR DESCRIPTION
Hey guys,

I have a very small PR to make the nakama-js client export all needed declarations for typescript. Currently users are not able to get a typed version of the `socket.send()` and all possible messages of this command.

Therefore I have extended the exports in the index.ts and tested it against a local build of nakama-js. 

One comment though: There is a duplicate interface definition of `ChannelMessage` both `socket.ts` and `client.ts` define this interface and they are not interoperable, as the clients version is all optional. (And defines a field `reference_id`, which has no usage in the project). Therefore I had to explicitly export the clients `ChannelMessage` to not make `socket.ts` override the declaration.