### PR TITLE
Fix XMLHttpRequest for Node Runtime

### DIFF
--- a/packages/nakama-js/dist/nakama-js.cjs.js
+++ b/packages/nakama-js/dist/nakama-js.cjs.js
@@ -621,9 +621,11 @@ var _atob = _hasatob ? (asc) => atob(_tidyB64(asc)) : _hasBuffer ? (asc) => Buff
 function buildFetchOptions(method, options, bodyJson) {
   const fetchOptions = __spreadValues(__spreadValues({}, { method }), options);
   fetchOptions.headers = __spreadValues({}, options.headers);
-  const descriptor = Object.getOwnPropertyDescriptor(XMLHttpRequest.prototype, "withCredentials");
-  if (!(descriptor == null ? void 0 : descriptor.set)) {
-    fetchOptions.credentials = "cocos-ignore";
+  if (typeof XMLHttpRequest !== "undefined") {
+    const descriptor = Object.getOwnPropertyDescriptor(XMLHttpRequest.prototype, "withCredentials");
+    if (!(descriptor == null ? void 0 : descriptor.set)) {
+      fetchOptions.credentials = "cocos-ignore";
+    }
   }
   if (!Object.keys(fetchOptions.headers).includes("Accept")) {
     fetchOptions.headers["Accept"] = "application/json";

--- a/packages/nakama-js/dist/nakama-js.esm.mjs
+++ b/packages/nakama-js/dist/nakama-js.esm.mjs
@@ -595,9 +595,11 @@ var _atob = _hasatob ? (asc) => atob(_tidyB64(asc)) : _hasBuffer ? (asc) => Buff
 function buildFetchOptions(method, options, bodyJson) {
   const fetchOptions = __spreadValues(__spreadValues({}, { method }), options);
   fetchOptions.headers = __spreadValues({}, options.headers);
-  const descriptor = Object.getOwnPropertyDescriptor(XMLHttpRequest.prototype, "withCredentials");
-  if (!(descriptor == null ? void 0 : descriptor.set)) {
-    fetchOptions.credentials = "cocos-ignore";
+  if (typeof XMLHttpRequest !== "undefined") {
+    const descriptor = Object.getOwnPropertyDescriptor(XMLHttpRequest.prototype, "withCredentials");
+    if (!(descriptor == null ? void 0 : descriptor.set)) {
+      fetchOptions.credentials = "cocos-ignore";
+    }
   }
   if (!Object.keys(fetchOptions.headers).includes("Accept")) {
     fetchOptions.headers["Accept"] = "application/json";

--- a/packages/nakama-js/dist/nakama-js.iife.js
+++ b/packages/nakama-js/dist/nakama-js.iife.js
@@ -621,9 +621,11 @@ var nakamajs = (() => {
   function buildFetchOptions(method, options, bodyJson) {
     const fetchOptions = __spreadValues(__spreadValues({}, { method }), options);
     fetchOptions.headers = __spreadValues({}, options.headers);
-    const descriptor = Object.getOwnPropertyDescriptor(XMLHttpRequest.prototype, "withCredentials");
-    if (!(descriptor == null ? void 0 : descriptor.set)) {
-      fetchOptions.credentials = "cocos-ignore";
+    if (typeof XMLHttpRequest !== "undefined") {
+      const descriptor = Object.getOwnPropertyDescriptor(XMLHttpRequest.prototype, "withCredentials");
+      if (!(descriptor == null ? void 0 : descriptor.set)) {
+        fetchOptions.credentials = "cocos-ignore";
+      }
     }
     if (!Object.keys(fetchOptions.headers).includes("Accept")) {
       fetchOptions.headers["Accept"] = "application/json";

--- a/packages/nakama-js/dist/nakama-js.umd.js
+++ b/packages/nakama-js/dist/nakama-js.umd.js
@@ -850,11 +850,13 @@
   function buildFetchOptions(method, options, bodyJson) {
       var fetchOptions = __assign({ method: method }, options);
       fetchOptions.headers = __assign({}, options.headers);
-      var descriptor = Object.getOwnPropertyDescriptor(XMLHttpRequest.prototype, "withCredentials");
-      // in Cocos Creator, XMLHttpRequest.withCredentials is not writable, so make the fetch
-      // polyfill avoid writing to it.
-      if (!(descriptor === null || descriptor === void 0 ? void 0 : descriptor.set)) {
-          fetchOptions.credentials = 'cocos-ignore'; // string value is arbitrary, cannot be 'omit' or 'include
+      if (typeof XMLHttpRequest !== "undefined") {
+          var descriptor = Object.getOwnPropertyDescriptor(XMLHttpRequest.prototype, "withCredentials");
+          // in Cocos Creator, XMLHttpRequest.withCredentials is not writable, so make the fetch
+          // polyfill avoid writing to it.
+          if (!(descriptor === null || descriptor === void 0 ? void 0 : descriptor.set)) {
+              fetchOptions.credentials = 'cocos-ignore'; // string value is arbitrary, cannot be 'omit' or 'include
+          }
       }
       if (!Object.keys(fetchOptions.headers).includes("Accept")) {
           fetchOptions.headers["Accept"] = "application/json";

--- a/packages/nakama-js/utils.ts
+++ b/packages/nakama-js/utils.ts
@@ -4,12 +4,14 @@ export function buildFetchOptions(method: string, options: any, bodyJson: string
     const fetchOptions = {...{ method: method }, ...options};
     fetchOptions.headers = {...options.headers};
 
-    const descriptor = Object.getOwnPropertyDescriptor(XMLHttpRequest.prototype, "withCredentials");
+    if (typeof XMLHttpRequest !== "undefined") {
+        const descriptor = Object.getOwnPropertyDescriptor(XMLHttpRequest.prototype, "withCredentials");
 
-    // in Cocos Creator, XMLHttpRequest.withCredentials is not writable, so make the fetch
-    // polyfill avoid writing to it.
-    if (!descriptor?.set) {
-      fetchOptions.credentials = 'cocos-ignore'; // string value is arbitrary, cannot be 'omit' or 'include
+        // in Cocos Creator, XMLHttpRequest.withCredentials is not writable, so make the fetch
+        // polyfill avoid writing to it.
+        if (!descriptor?.set) {
+            fetchOptions.credentials = 'cocos-ignore'; // string value is arbitrary, cannot be 'omit' or 'include
+        }
     }
 
     if(!Object.keys(fetchOptions.headers).includes("Accept")) {


### PR DESCRIPTION
If using this JS SDK without the browser, `XMLHttpRequest` won't exist - therefore this error occurs:

```
const descriptor = Object.getOwnPropertyDescriptor(XMLHttpRequest.prototype, "withCredentials");
                                                     ^
ReferenceError: XMLHttpRequest is not defined
```

In order to fix this we should check if XMLHttpRequest exists first before.