### PR TITLE
Implemented `onheartbeattimeout` callback for ping/pong.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [keep a changelog](http://keepachangelog.com/) and this p
 
 ### Unreleased
 
+### [2.6.1]
+
+### Added
+
+- You can now pass a `onheartbeattimeout` to the socket which will be called directly when a heartbeat timeout occurs. It will also still call `ondisconnect` once the socket is closed (which can take a few seconds for some browsers).
+
+
 ### [2.6.0]
 
 ### Added

--- a/packages/nakama-js/dist/nakama-js.cjs.js
+++ b/packages/nakama-js/dist/nakama-js.cjs.js
@@ -3308,6 +3308,11 @@ var _DefaultSocket = class {
       console.log(streamData);
     }
   }
+  onheartbeattimeout() {
+    if (this.verbose && window && window.console) {
+      console.log("Heartbeat timeout.");
+    }
+  }
   send(message, sendTimeout = _DefaultSocket.DefaultSendTimeoutMs) {
     const untypedMessage = message;
     return new Promise((resolve, reject) => {
@@ -3544,6 +3549,7 @@ var _DefaultSocket = class {
           if (window && window.console) {
             console.error("Server unreachable from heartbeat.");
           }
+          this.onheartbeattimeout();
           this.adapter.close();
         }
         return;

--- a/packages/nakama-js/dist/nakama-js.esm.mjs
+++ b/packages/nakama-js/dist/nakama-js.esm.mjs
@@ -3282,6 +3282,11 @@ var _DefaultSocket = class {
       console.log(streamData);
     }
   }
+  onheartbeattimeout() {
+    if (this.verbose && window && window.console) {
+      console.log("Heartbeat timeout.");
+    }
+  }
   send(message, sendTimeout = _DefaultSocket.DefaultSendTimeoutMs) {
     const untypedMessage = message;
     return new Promise((resolve, reject) => {
@@ -3518,6 +3523,7 @@ var _DefaultSocket = class {
           if (window && window.console) {
             console.error("Server unreachable from heartbeat.");
           }
+          this.onheartbeattimeout();
           this.adapter.close();
         }
         return;

--- a/packages/nakama-js/dist/nakama-js.iife.js
+++ b/packages/nakama-js/dist/nakama-js.iife.js
@@ -3308,6 +3308,11 @@ var nakamajs = (() => {
         console.log(streamData);
       }
     }
+    onheartbeattimeout() {
+      if (this.verbose && window && window.console) {
+        console.log("Heartbeat timeout.");
+      }
+    }
     send(message, sendTimeout = _DefaultSocket.DefaultSendTimeoutMs) {
       const untypedMessage = message;
       return new Promise((resolve, reject) => {
@@ -3544,6 +3549,7 @@ var nakamajs = (() => {
             if (window && window.console) {
               console.error("Server unreachable from heartbeat.");
             }
+            this.onheartbeattimeout();
             this.adapter.close();
           }
           return;

--- a/packages/nakama-js/dist/nakama-js.umd.js
+++ b/packages/nakama-js/dist/nakama-js.umd.js
@@ -4040,6 +4040,11 @@
               console.log(streamData);
           }
       };
+      DefaultSocket.prototype.onheartbeattimeout = function () {
+          if (this.verbose && window && window.console) {
+              console.log("Heartbeat timeout.");
+          }
+      };
       DefaultSocket.prototype.send = function (message, sendTimeout) {
           var _this = this;
           if (sendTimeout === void 0) { sendTimeout = DefaultSocket.DefaultSendTimeoutMs; }
@@ -4390,6 +4395,7 @@
                               if (window && window.console) {
                                   console.error("Server unreachable from heartbeat.");
                               }
+                              this.onheartbeattimeout();
                               this.adapter.close();
                           }
                           return [2 /*return*/];

--- a/packages/nakama-js/dist/socket.d.ts
+++ b/packages/nakama-js/dist/socket.d.ts
@@ -640,6 +640,7 @@ export declare class DefaultSocket implements Socket {
     onstatuspresence(statusPresence: StatusPresenceEvent): void;
     onstreampresence(streamPresence: StreamPresenceEvent): void;
     onstreamdata(streamData: StreamData): void;
+    onheartbeattimeout(): void;
     send(message: ChannelJoin | ChannelLeave | ChannelMessageSend | ChannelMessageUpdate | ChannelMessageRemove | CreateMatch | JoinMatch | LeaveMatch | MatchDataSend | MatchmakerAdd | MatchmakerRemove | PartyAccept | PartyClose | PartyCreate | PartyDataSend | PartyJoin | PartyJoinRequestList | PartyLeave | PartyMatchmakerAdd | PartyMatchmakerRemove | PartyPromote | PartyRemove | Rpc | StatusFollow | StatusUnfollow | StatusUpdate | Ping, sendTimeout?: number): Promise<any>;
     acceptPartyMember(party_id: string, presence: Presence): Promise<void>;
     addMatchmaker(query: string, min_count: number, max_count: number, string_properties?: Record<string, string>, numeric_properties?: Record<string, number>): Promise<MatchmakerTicket>;

--- a/packages/nakama-js/socket.ts
+++ b/packages/nakama-js/socket.ts
@@ -977,6 +977,12 @@ export class DefaultSocket implements Socket {
     }
   }
 
+  onheartbeattimeout() {
+    if (this.verbose && window && window.console) {
+      console.log("Heartbeat timeout.");
+    }
+  }
+
   send(message: ChannelJoin | ChannelLeave | ChannelMessageSend | ChannelMessageUpdate |
     ChannelMessageRemove | CreateMatch | JoinMatch | LeaveMatch | MatchDataSend | MatchmakerAdd |
     MatchmakerRemove | PartyAccept | PartyClose | PartyCreate | PartyDataSend | PartyJoin |
@@ -1230,6 +1236,7 @@ export class DefaultSocket implements Socket {
             if (window && window.console) {
                 console.error("Server unreachable from heartbeat.");
             }
+            this.onheartbeattimeout();
             this.adapter.close();
         }
 


### PR DESCRIPTION
It seems the `socket.onDisconnect` callback function is called late. But we do see the `Server unreachable from heartbeat` error message very quickly (setHeartbeatTimeoutMs = 3000ms) after disabling WiFi. I’ve debugged this a bit, it’s calling `WebSocketAdapterText:close`, but takes some time before calling the `WebSocketAdapterText.onClose` callback (which calls the `socket.onDisconnect`)

My idea is that the `WebSocket.close` function is taking a while before completing since it’s doing a closing handshake on the socket (see: [WebSocket.close() - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close)).

This PR implements an additional callback `onheartbeattimeout` which will be called directly when the ping/pong failed. This way we can detect connection problems sooner and inform the players. We have conducted internal testing on this build and verified that it is functioning properly.