### PR TITLE
New method that takes host and post as arg for connect-socket

### DIFF
--- a/packages/nakama-js/client.ts
+++ b/packages/nakama-js/client.ts
@@ -698,6 +698,11 @@ export class Client {
     return new DefaultSocket(this.host, this.port, useSSL, verbose, adapter, sendTimeoutMs);
   }
 
+  /** A socket created from different host or port from client */
+  createSocketCustom(host: string, port: string, useSSL = false, verbose: boolean = false, adapter : WebSocketAdapter = new WebSocketAdapterText(), sendTimeoutMs : number = DefaultSocket.DefaultSendTimeoutMs): Socket {
+    return new DefaultSocket(host, port, useSSL, verbose, adapter, sendTimeoutMs);
+  }
+
   /** Delete one or more users by ID or username. */
   async deleteFriends(session: Session, ids?: Array<string>, usernames?: Array<string>): Promise<boolean> {
     if (this.autoRefreshSession && session.refresh_token &&


### PR DESCRIPTION
Created a custom version of [createSocket](https://github.com/heroiclabs/nakama-js/blob/dfc10216069a2bda7286192d22109829311bf32a/packages/nakama-js/client.ts#LL697C5-L697C5) that takes host and/port port as argument

Resolves https://github.com/heroiclabs/nakama-js/issues/158

