### PR TITLE
Addresses type definition discoverability issue

### DIFF
--- a/packages/nakama-js/package.json
+++ b/packages/nakama-js/package.json
@@ -7,6 +7,7 @@
     "description": "JavaScript client for Nakama server written in TypeScript.",
     "main": "dist/nakama-js.cjs.js",
     "module": "dist/nakama-js.esm.mjs",
+    "types": "dist/index.d.ts",
     "exports": {
         "./package.json": "./package.json",
         ".": {

--- a/packages/nakama-js/package.json
+++ b/packages/nakama-js/package.json
@@ -7,10 +7,10 @@
     "description": "JavaScript client for Nakama server written in TypeScript.",
     "main": "dist/nakama-js.cjs.js",
     "module": "dist/nakama-js.esm.mjs",
-    "types": "dist/index.d.ts",
     "exports": {
         "./package.json": "./package.json",
         ".": {
+	    "types": "./dist/index.d.ts",
             "import": "./dist/nakama-js.esm.mjs",
             "require": "./dist/nakama-js.cjs.js"
         }


### PR DESCRIPTION
I have a newly created Vite project setup, and when trying to use `nakama-js` I see the following:


> Could not find a declaration file for module '@heroiclabs/nakama-js'. '/home/foundrium/code/nakama-poc/node_modules/@heroiclabs/nakama-js/dist/nakama-js.esm.mjs' implicitly has an 'any' type. There are types at '/home/foundrium/code/nakama-poc/node_modules/@heroiclabs/nakama-js/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@heroiclabs/nakama-js' library may need to update its package.json or typings.ts(7016)
  
I tested this fix locally with `npm link` and the error goes away, but I don't have a clear picture of what it would mean for other setups. Will leave it to the maintainers to decide if its worth merging.