### PR TITLE
rpcHttpKey function uses POST now

### DIFF
--- a/packages/nakama-js/client.ts
+++ b/packages/nakama-js/client.ts
@@ -1601,7 +1601,7 @@ export class Client {
 
   /** Execute an RPC function on the server. */
   async rpcHttpKey(httpKey: string, id: string, input?: object): Promise<RpcResponse> {
-    return this.apiClient.rpcFunc2("", id, input && JSON.stringify(input) || "", httpKey)
+    return this.apiClient.rpcFunc("", id, input && JSON.stringify(input) || "", httpKey)
       .then((response: ApiRpc) => {
         return Promise.resolve({
           id: response.id,


### PR DESCRIPTION
fixes #162 and #133 
(and also probably https://github.com/heroiclabs/nakama/issues/400 )

even though you could argue that you throw the payload part of a GET request away by intention, using POST for server-to-server calls is even a security bonus, as the possibility to sniff query params gets eliminated.

Also nowhere in the docs it is mentioned, that "input" is not a thing in these rpcHttpKey-calls. This PR fixes that and makes the "input" param actually behave the same way, that session-authorized rpc's do.