### PR TITLE
Fix documentation to send a chat

### DIFF
--- a/packages/nakama-js/README.md
+++ b/packages/nakama-js/README.md
@@ -141,15 +141,15 @@ socket.onchannelmessage = (message) => {
 
 
 // 1 = room, 2 = Direct Message, 3 = Group
-const type : number = 1;
 const roomname = "mychannel";
-const persistence : boolean = false;
-const hidden : boolean = false;
+const type: number = 1;
+const persistence: boolean = false;
+const hidden: boolean = false;
 
-const channel = await socket.joinChat(type, roomname, persistence, hidden);
+const channel = await socket.joinChat(roomname, type, persistence, hidden);
 
-const message = { "hello": "world" };
-socket.writeChatMessage(channel.channel.id, message);
+const message = { hello: "world" };
+socket.writeChatMessage(channel.id, message);
 ```
 
 ## Handling errors


### PR DESCRIPTION
See the function signature below:

```
joinChat(target: string, type: number, persistence: boolean, hidden: boolean): Promise<Channel>;
```

Currently `socket.joinChat()` example is not used correctly. The first argument should be target, then type. Also, the function will return Promise of Channel object (`Promise<Channel>`) therefore I changed from `channel.channel.id` to `channel.id`.

Tested on Chrome Version 122.0.6261.69