### PR TITLE
only close adapter if it is open

### DIFF
--- a/packages/nakama-js/socket.ts
+++ b/packages/nakama-js/socket.ts
@@ -846,7 +846,10 @@ export class DefaultSocket implements Socket {
       }
       this.adapter.onError = (evt: Event) => {
         reject(evt);
-        this.adapter.close();
+        
+        if (this.adapter.isOpen()) {
+          this.adapter.close();
+        }
       }
 
 


### PR DESCRIPTION
We are seeing errors in production where this code in `socket.ts`:

```js
this.adapter.onError = (evt) => {
        reject(evt);
        this.adapter.close();
};
```

Calls this:

```js
close() {
    this._socket.close();
    this._socket = void 0;
}
```

But `this._socket` is undefined and throws an error. This throws a TypeError inside of a Promise constructor, which is then unhandled because the promise is already rejected. This can be demonstrated very succinctly with this bit of code:

```js
const foo = () => new Promise((res, rej) => {
  rej('Error A');

  throw new Error('Error B');
});

const run = async () => {
  try {
    await foo();
  } catch(error) {
    console.log('Caught an error: ' + error);
  }
};

run();
```

This will output: `Caught an error: Error A`, whereas `Error B` cannot be handled.

To fix this, mirroring all other calls to `this.adapter.close()`, we simply need to wrap with a check that the adapter is indeed open.
